### PR TITLE
XSS Protection for renderData()

### DIFF
--- a/sticker/Sticker.cfc
+++ b/sticker/Sticker.cfc
@@ -123,6 +123,10 @@ component {
 			requestStorage[ arguments.group ] = StructNew( "linked" );
 		}
 
+		structEach( data, function( key, value ) {
+			data[ key ] = encodeForHTML( value );
+		} );
+
 		requestStorage[ arguments.group ].append( arguments.data );
 
 		return this;

--- a/sticker/Sticker.cfc
+++ b/sticker/Sticker.cfc
@@ -123,10 +123,6 @@ component {
 			requestStorage[ arguments.group ] = StructNew( "linked" );
 		}
 
-		structEach( data, function( key, value ) {
-			data[ key ] = encodeForHTML( value );
-		} );
-
 		requestStorage[ arguments.group ].append( arguments.data );
 
 		return this;

--- a/sticker/util/IncludeRenderer.cfc
+++ b/sticker/util/IncludeRenderer.cfc
@@ -59,6 +59,14 @@ component {
 	 * @data.hint Structure of data to be available to javascript
 	 */
 	public string function renderData( required struct data, string variableName="cfrequest" ) {
+		for ( var key in arguments.data ) {
+			var value = arguments.data[ key ];
+
+			if ( isSimpleValue( value ) ) {
+				arguments.data[ key ] = HTMLEditFormat( value );
+			}
+		}
+
 		return '<script>#arguments.variableName#=#SerializeJson( arguments.data )#</script>';
 	}
 

--- a/tests/unit/IncludeRendererTest.cfc
+++ b/tests/unit/IncludeRendererTest.cfc
@@ -72,6 +72,20 @@ component extends="testbox.system.BaseSpec"{
 
 			} );
 
+			it( "should avoid outputting executable code for example when data is unsanitized could be vulnerable to xss", function(){
+				var testData  = StructNew( "linked" );
+				var xssAttack = "</SCript><svG/onLoad=prompt(/xss/)>";
+				var escaped   = EncodeForJavaScript( xssAttack );
+
+				testData[ "thisIsAnArray"  ] = [ 1,2,3,4,xssAttack];
+				testData[ "thisIsAnObject" ] = { "thisIsAKey"=xssAttack, "aontherKey"=[1,4,{},false,escaped]};
+				testData[ "interesting"    ] = NullValue();
+				testData[ "vulnerable"    ] = xssAttack
+
+				var expectedResult = '<script>cfrequest={"thisIsAnArray":[1,2,3,4,"five", "#escaped#"],"thisIsAnObject":{"thisIsAKey":"#escaped#","aontherKey":[1,4,{},false,"#escaped#"]},"interesting":null,"vulnerable":"#escaped#"}</script>'
+				expect( renderer.renderData( data=testData ) ).toBe( expectedResult );
+			} );
+
 		} );
 
 		describe( "wrapWithIeConditional()", function(){

--- a/tests/unit/IncludeRendererTest.cfc
+++ b/tests/unit/IncludeRendererTest.cfc
@@ -51,11 +51,11 @@ component extends="testbox.system.BaseSpec"{
 			it( "should return a script block with passed data rendered as a JavaScript object", function(){
 				var testData = StructNew( "linked" );
 
-				testData[ "thisIsAnArray"  ] = [ 1,2,3,4,"five"];
+				testData[ "thisIsAnArray"  ] = [ 1,2,3,4,"five","2023-09-19 12:49:00.000" ];
 				testData[ "thisIsAnObject" ] = { "thisIsAKey"="and a value", "aontherKey"=[1,4,{},false]};
 				testData[ "interesting"    ] = NullValue();
 
-				var expectedResult = '<script>cfrequest={"thisIsAnArray":[1,2,3,4,"five"],"thisIsAnObject":{"thisIsAKey":"and a value","aontherKey":[1,4,{},false]},"interesting":null}</script>'
+				var expectedResult = '<script>cfrequest={"thisIsAnArray":[1,2,3,4,"five","2023-09-19 12:49:00.000"],"thisIsAnObject":{"thisIsAKey":"and a value","aontherKey":[1,4,{},false]},"interesting":null}</script>'
 
 				expect( renderer.renderData( data=testData ) ).toBe( expectedResult );
 			} );
@@ -75,14 +75,14 @@ component extends="testbox.system.BaseSpec"{
 			it( "should avoid outputting executable code for example when data is unsanitized could be vulnerable to xss", function(){
 				var testData  = StructNew( "linked" );
 				var xssAttack = "</SCript><svG/onLoad=prompt(/xss/)>";
-				var escaped   = EncodeForJavaScript( xssAttack );
+				var escaped   = HTMLEditFormat( xssAttack );
 
 				testData[ "thisIsAnArray"  ] = [ 1,2,3,4,xssAttack];
 				testData[ "thisIsAnObject" ] = { "thisIsAKey"=xssAttack, "aontherKey"=[1,4,{},false,escaped]};
 				testData[ "interesting"    ] = NullValue();
-				testData[ "vulnerable"    ] = xssAttack
+				testData[ "vulnerable"     ] = xssAttack
 
-				var expectedResult = '<script>cfrequest={"thisIsAnArray":[1,2,3,4,"five", "#escaped#"],"thisIsAnObject":{"thisIsAKey":"#escaped#","aontherKey":[1,4,{},false,"#escaped#"]},"interesting":null,"vulnerable":"#escaped#"}</script>'
+				var expectedResult = '<script>cfrequest={"thisIsAnArray":[1,2,3,4,"#escaped#"],"thisIsAnObject":{"thisIsAKey":"#escaped#","aontherKey":[1,4,{},false,"#escaped#"]},"interesting":null,"vulnerable":"#escaped#"}</script>'
 				expect( renderer.renderData( data=testData ) ).toBe( expectedResult );
 			} );
 


### PR DESCRIPTION
Adds some sensible level of sanitisation to renderData (for includeData()). Keys are:

1. Numbers + booleans should remain untouched
2. Already escaped output should not be re-escaped
3. Only escape output with potential bad chars to limit false negative behaviour