### PR TITLE
STICKER-4 support csp nonces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,8 @@ jobs:
           output_file: /tests/test-results.txt
 
       - name: Upload test results
-        uses: actions/upload-artifact@v1
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: tests/test-results.txt

--- a/sticker/Sticker.cfc
+++ b/sticker/Sticker.cfc
@@ -168,7 +168,7 @@ component {
 	 * I ensure all includes are rendered in the correct order
 	 *
 	 */
-	public string function renderIncludes( string type, string group="default" ) {
+	public string function renderIncludes( string type, string group="default", string nonce="" ) {
 		var includes      = _getRequestStorage();
 		var adhocUrls     = _getRequestStorage( "adhoc" );
 		var fullSortOrder = _getSortOrder();
@@ -194,7 +194,7 @@ component {
 				if ( t == "js" ) {
 					var data = _getRequestStorage( "data" );
 					if ( data.keyExists( arguments.group ) ) {
-						rendered &= _getIncludeRenderer().renderData( data[ arguments.group ] ) & Chr(13) & Chr(10);
+						rendered &= _getIncludeRenderer().renderData( data=data[ arguments.group ], nonce=arguments.nonce ) & Chr(13) & Chr(10);
 					}
 				}
 				for( var asset in ordered ){

--- a/sticker/util/IncludeRenderer.cfc
+++ b/sticker/util/IncludeRenderer.cfc
@@ -58,8 +58,12 @@ component {
 	 *
 	 * @data.hint Structure of data to be available to javascript
 	 */
-	public string function renderData( required struct data, string variableName="cfrequest" ) {
-		return '<script>#arguments.variableName#=#SerializeJson( _sanitizeJsData( arguments.data ) )#</script>';
+	public string function renderData( required struct data, string variableName="cfrequest", string nonce="" ) {
+		var attribs = "";
+		if ( Len( Trim( arguments.nonce ) ) ) {
+			attribs = ' nonce="' & EncodeForHtmlAttribute( arguments.nonce ) & '"';
+		}
+		return '<script#attribs#>#arguments.variableName#=#SerializeJson( _sanitizeJsData( arguments.data ) )#</script>';
 	}
 
 	/**

--- a/tests/unit/IncludeRendererTest.cfc
+++ b/tests/unit/IncludeRendererTest.cfc
@@ -86,6 +86,12 @@ component extends="testbox.system.BaseSpec"{
 				expect( renderer.renderData( data=testData ) ).toBe( expectedResult );
 			} );
 
+			it( "should include nonce attribute when passed", function(){
+				var testData = StructNew( "linked" );
+				var expectedResult = '<script nonce="1234567890">cfrequest={}</script>'
+				expect( renderer.renderData( data=testData, nonce="1234567890" ) ).toBe( expectedResult );
+			} );
+
 		} );
 
 		describe( "wrapWithIeConditional()", function(){

--- a/tests/unit/StickerTest.cfc
+++ b/tests/unit/StickerTest.cfc
@@ -255,6 +255,24 @@ component extends="testbox.system.BaseSpec"{
 			);
 		} );
 
+		it( "should include nonce attribute when passed to renderIncludes()", function(){
+			var sticker = new sticker.Sticker();
+
+			sticker.addBundle( rootDirectory="/resources/bundles/bundle1/", rootUrl="http://bundle1.com/assets" )
+			       .addBundle( rootDirectory="/resources/bundles/bundle2/", rootUrl="http://bundle2.com/assets" )
+			       .load();
+
+			sticker.include( "js-someplugin" )
+			       .includeData( { key1="key1" } )
+			       .includeData( { key2="key2" } )
+			       .includeData( { key3="key3" } );
+
+			expect( sticker.renderIncludes( type="js", nonce="1234567890" ) ).toBe(
+				'<script nonce="1234567890">cfrequest={"key1":"key1","key2":"key2","key3":"key3"}</script>' & Chr(13) & Chr(10) &
+				'<script src="http://bundle2.com/assets/js/someplugin.min.js"></script>' & Chr(13) & Chr(10)
+			);
+		} );
+
 		it( "should render any dependencies that have not been explicity included", function(){
 			var sticker = new sticker.Sticker();
 


### PR DESCRIPTION
Change here to allow passing a nonce value into `renderIncludes()`. This will have the effect of outputting this value in the nonce attribute for the raw `<script>` tags that we use for including data.

This helps Content Security Policy to be able to trust the script and not rely on allowing all inline scripts.